### PR TITLE
fix: deal with non-existant install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,11 @@
 
   - copy: src=ntp.service dest=/lib/systemd/system/ owner=root mode=0644
 
-  - systemd: name=systemd-timesyncd.service enabled=no state=stopped
+  - systemd:
+      name: systemd-timesyncd.service
+      enabled: no
+      state: stopped
+    ignore_errors: yes
 
   - systemd: name=ntp.service  enabled=yes state=restarted
 


### PR DESCRIPTION
I used this script on another debian system and it worked fine, except when systemd-timesyncd wasn't installed (sometimes it was, sometimes it wasn't).

